### PR TITLE
Make dev neo part of install, and fix lil bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "statsmodels",
     "scikit-image",
     "cmocean",
-    "pydantic>2.4.2"
+    "pydantic>2.4.2",
+    "neo@git+https://github.com/NeuralEnsemble/python-neo.git",
 ]
 
 [build-system]

--- a/src/Elrond/Helpers/plot_utility.py
+++ b/src/Elrond/Helpers/plot_utility.py
@@ -160,7 +160,7 @@ def style_track_plot_no_cue(ax, track_length, alpha=0.25):
     ax.axvspan(0, 30, facecolor='k', linewidth =0, alpha=.25) # black box
     ax.axvspan(track_length-30, track_length, facecolor='k', linewidth =0, alpha=alpha)# black box
 
- def style_track_plot_only_black_boxes(ax, track_length, alpha=0.25):
+def style_track_plot_only_black_boxes(ax, track_length, alpha=0.25):
     ax.axvspan(0, 30, facecolor='k', linewidth =0, alpha=.25) # black box
     ax.axvspan(track_length-30, track_length, facecolor='k', linewidth =0, alpha=alpha)# black box
     


### PR DESCRIPTION
Will make
`pip install -e .` 
install the dev version of neo, hopefully unfreezing the sync functions. 

Also lil bug fix which was crashing some imports.